### PR TITLE
Add minimal NebulaX boot demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# NebulaX OS Demo
+
+This repository contains a minimal bootable example of the NebulaX operating system concept. The demo is a 512-byte boot sector that simply prints a message using BIOS services. It can be run with QEMU on Windows or Linux.
+
+## Building
+
+1. Install [NASM](https://www.nasm.us/) and [QEMU](https://www.qemu.org/).
+2. Open a terminal in the `nebulax-os` directory.
+3. Run:
+
+```bash
+make
+```
+
+This assembles `boot.asm` into `nebulax.bin`.
+
+## Running in QEMU
+
+Run the following from the `nebulax-os` directory:
+
+```bash
+make run
+```
+
+You should see a window displaying `NebulaX booted successfully!`.
+
+## Files
+
+- `nebulax-os/boot.asm` – assembly source for the boot sector
+- `nebulax-os/Makefile` – build and run commands
+- `starlight.py` – prototype interpreter for the Starlight language
+- `hello.stl` – example Starlight script
+
+The boot demo is intentionally small and does not yet implement the full NebulaX kernel concepts, but it demonstrates how the project can start from first principles.

--- a/hello.stl
+++ b/hello.stl
@@ -1,0 +1,3 @@
+start <- event {
+    display("Welcome to NebulaX")
+}

--- a/nebulax-os/Makefile
+++ b/nebulax-os/Makefile
@@ -1,0 +1,10 @@
+all: nebulax.bin
+
+nebulax.bin: boot.asm
+	nasm -f bin boot.asm -o nebulax.bin
+
+run: nebulax.bin
+	qemu-system-x86_64 -drive format=raw,file=nebulax.bin
+
+clean:
+	rm -f nebulax.bin

--- a/nebulax-os/boot.asm
+++ b/nebulax-os/boot.asm
@@ -1,0 +1,26 @@
+org 0x7c00
+
+; Bootloader for NebulaX minimal demo
+
+mov ax, 0x07c0
+mov ds, ax
+mov si, msg
+
+print:
+    lodsb
+    or al, al
+    jz done
+    mov ah, 0x0e
+    mov bx, 0x0007
+    int 0x10
+    jmp print
+
+done:
+    cli
+    hlt
+
+msg db 'NebulaX booted successfully!', 0
+
+; Pad remainder of boot sector
+ times 510-($-$$) db 0
+ dw 0xaa55

--- a/starlight.py
+++ b/starlight.py
@@ -1,0 +1,44 @@
+"""Minimal Starlight interpreter prototype for NebulaX.
+This is not a full implementation. It simply executes events defined
+as dictionaries for demonstration purposes.
+"""
+import sys
+
+# Simple parser for the prototype: lines of the form 'name <- event { ... }'
+# We only handle the display command.
+
+def parse(source):
+    events = {}
+    name = None
+    for line in source.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if '<- event' in line:
+            name = line.split('<-')[0].strip()
+            events[name] = []
+        elif line == '}':
+            name = None
+        elif name is not None:
+            if line.startswith('display(') and line.endswith(')'):
+                msg = line[len('display('):-1].strip('"')
+                events[name].append(('display', msg))
+    return events
+
+
+def run(events):
+    # In NebulaX each event would run when its inputs are ready.
+    # Here we just execute in definition order.
+    for name, actions in events.items():
+        for action, value in actions:
+            if action == 'display':
+                print(value)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: starlight.py <file>')
+        sys.exit(1)
+    with open(sys.argv[1]) as f:
+        source = f.read()
+    events = parse(source)
+    run(events)

--- a/unique-os-design.md
+++ b/unique-os-design.md
@@ -1,0 +1,31 @@
+# NebulaX: A Unique Operating System Concept
+
+NebulaX is a research operating system built entirely from first principles. It does not reuse existing OS concepts. Everything from hardware management to user experience is reinvented.
+
+## Core Ideas
+
+- **Quantum Event Kernel**: Instead of processes and threads, NebulaX uses "quantum events," ephemeral execution units that activate only when their dependencies are satisfied. Scheduling is event-driven rather than time-sliced.
+- **Spatial Memory Fabric**: Memory is addressed by coordinates rather than linear addresses. The kernel tracks clusters of memory tiles, allowing programs to allocate memory in 3‑D space.
+- **Protocol-Free I/O**: Drivers expose raw hardware capabilities. Applications negotiate their own data formats and semantics directly with the driver API.
+
+## Starlight Language
+
+NebulaX applications are written in Starlight, a domain-specific language designed for the quantum event model.
+
+```
+# sample.stl - a Starlight snippet
+start <- event {
+    display("Hello from NebulaX")
+}
+```
+
+The syntax uses `<-` to define events. Each event executes once its inputs are ready. There is no global state; all data flows through events.
+
+## Polychrome GUI
+
+NebulaX comes with Polychrome, a graphical shell where windows are arranged on translucent layers in 3‑D space. Users navigate by rotating the workspace and placing applications on different spatial planes.
+
+
+## Boot Demo
+
+A minimal boot sector is included under `nebulax-os/`. It prints a welcome message using BIOS services. Build it with `make` and run with `make run` using QEMU.


### PR DESCRIPTION
## Summary
- document how to assemble and run the minimal NebulaX boot sector
- add boot sector source and Makefile
- update OS design doc with boot demo notes

## Testing
- `python3 starlight.py hello.stl`
- `make -C nebulax-os run` *(fails: qemu-system-x86_64 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598a78ccf88329ada937a9b6417766